### PR TITLE
Fix trex_match Logic

### DIFF
--- a/test.c
+++ b/test.c
@@ -10,6 +10,40 @@
 
 /* test edited by Kai Uwe Jesussek for parsing html*/
 
+void trex_test(const TRexChar *regex, const TRexChar *text, const TRexBool expected) {
+	const TRexChar *error = NULL;
+	TRex *regex_compiled = trex_compile(_TREXC(regex), &error);
+
+	// Check for regex compilation errors
+	if (!regex_compiled) {
+		trex_printf(_TREXC("Compilation error [%s]!\n"), error ? error : _TREXC("undefined"));
+	}
+
+	TRexBool result = trex_match(regex_compiled, text);
+
+	#ifdef _DEBUG
+		printf("DEBUG trex_test: result = %d\n", result);
+		printf("DEBUG trex_test: expected = %d\n", expected);
+	#endif
+
+	// Print matching outcome compared to expected outcome
+	if (result == expected) {
+		if (result == TRex_True) {
+			trex_printf("True positive: String '%s' matched.\n", regex);
+		} else {
+			trex_printf("True negative: No matches for '%s'.\n", regex);
+		}
+	} else {
+		if (result == TRex_True) {
+			trex_printf("FALSE POSITIVE: STRING '%s' SHOULD NOT HAVE MATCHED!\n", regex);
+		} else {
+			trex_printf("FALSE NEGATIVE: STRING '%s' SHOULD HAVE MATCHED.\n", regex);
+		}
+	}
+
+	trex_free(regex_compiled);
+}
+
 int main(int argc, char* argv[])
 {
 	const TRexChar *begin,*end;
@@ -39,5 +73,39 @@ int main(int argc, char* argv[])
 	else {
 		trex_printf(_TREXC("compilation error [%s]!\n"),error?error:_TREXC("undefined"));
 	}
+
+	// Negative testing for strings that shouldn't match
+	TRexChar regex_str[200];
+	TRexChar test_string[200];
+	trex_sprintf(test_string, _TREXC("Match some part of this string."));
+
+	trex_printf("=============================\n");
+	trex_printf("Simple matching string cases.\n");
+	trex_printf("Test string: %s\n", test_string);
+
+	trex_printf("Test 1: missing letter\n");
+	trex_sprintf(regex_str, _TREXC("soe"));
+	trex_test(regex_str, test_string, TRex_False);
+
+	trex_printf("Test 2: missing space\n");
+	trex_sprintf(regex_str, _TREXC("matchs"));
+	trex_test(regex_str, test_string, TRex_False);
+
+	trex_printf("Test 3a: case mismatch\n");
+	trex_sprintf(regex_str, _TREXC("match"));
+	trex_test(regex_str,test_string, TRex_False);
+	trex_printf("Test 3b: case match\n");
+	trex_sprintf(regex_str, _TREXC("Match"));
+	trex_test(regex_str,test_string, TRex_True);
+
+	trex_printf("Test 4: unused character\n");
+	trex_sprintf(regex_str, _TREXC("!"));
+	trex_test(regex_str, test_string, TRex_False);
+
+	trex_printf("Test 5: single character\n");
+	trex_sprintf(regex_str, _TREXC("."));
+	trex_test(regex_str, test_string, TRex_True);
+	// End negative testing
+
 	return 0;
 }

--- a/trex.c
+++ b/trex.c
@@ -105,7 +105,7 @@ static void trex_error(TRex *exp,const TRexChar *error)
 }
 
 static void trex_expect(TRex *exp, int n){
-	if((*exp->_p) != n) 
+	if((*exp->_p) != n)
 		trex_error(exp, _SC("expected paren"));
 	exp->_p++;
 }
@@ -144,31 +144,31 @@ static int trex_charnode(TRex *exp,TRexBool isclass)
 			case 'r': exp->_p++; return trex_newnode(exp,'\r');
 			case 'f': exp->_p++; return trex_newnode(exp,'\f');
 			case 'v': exp->_p++; return trex_newnode(exp,'\v');
-			case 'a': case 'A': case 'w': case 'W': case 's': case 'S': 
-			case 'd': case 'D': case 'x': case 'X': case 'c': case 'C': 
-			case 'p': case 'P': case 'l': case 'u': 
+			case 'a': case 'A': case 'w': case 'W': case 's': case 'S':
+			case 'd': case 'D': case 'x': case 'X': case 'c': case 'C':
+			case 'p': case 'P': case 'l': case 'u':
 				{
-				t = *exp->_p; exp->_p++; 
+				t = *exp->_p; exp->_p++;
 				return trex_charclass(exp,t);
 				}
-			case 'b': 
+			case 'b':
 			case 'B':
 				if(!isclass) {
 					int node = trex_newnode(exp,OP_WB);
 					exp->_nodes[node].left = *exp->_p;
-					exp->_p++; 
+					exp->_p++;
 					return node;
 				} //else default
-			default: 
-				t = *exp->_p; exp->_p++; 
+			default:
+				t = *exp->_p; exp->_p++;
 				return trex_newnode(exp,t);
 		}
 	}
 	else if(!scisprint(*exp->_p)) {
-		
+
 		trex_error(exp,_SC("letter expected"));
 	}
-	t = *exp->_p; exp->_p++; 
+	t = *exp->_p; exp->_p++;
 	return trex_newnode(exp,t);
 }
 static int trex_class(TRex *exp)
@@ -179,11 +179,11 @@ static int trex_class(TRex *exp)
 		ret = trex_newnode(exp,OP_NCLASS);
 		exp->_p++;
 	}else ret = trex_newnode(exp,OP_CLASS);
-	
+
 	if(*exp->_p == ']') trex_error(exp,_SC("empty class"));
 	chain = ret;
 	while(*exp->_p != ']' && exp->_p != exp->_eol) {
-		if(*exp->_p == '-' && first != -1){ 
+		if(*exp->_p == '-' && first != -1){
 			int r,t;
 			if(*exp->_p++ == ']') trex_error(exp,_SC("unfinished range"));
 			r = trex_newnode(exp,OP_RANGE);
@@ -297,7 +297,7 @@ static int trex_element(TRex *exp)
 				trex_error(exp,_SC(", or } expected"));
 		}
 		/*******************************/
-		isgreedy = TRex_True; 
+		isgreedy = TRex_True;
 		break;
 
 		}
@@ -384,7 +384,7 @@ static TRexBool trex_matchclass(TRex* exp,TRexNode *node,TRexChar c)
 
 static const TRexChar *trex_matchnode(TRex* exp,TRexNode *node,const TRexChar *str,TRexNode *next)
 {
-	
+
 	TRexNodeType type = node->type;
 	switch(type) {
 	case OP_GREEDY: {
@@ -428,7 +428,7 @@ static const TRexChar *trex_matchnode(TRex* exp,TRexNode *node,const TRexChar *s
 					}
 				}
 			}
-			
+
 			if(s >= exp->_eol)
 				break;
 		}
@@ -467,7 +467,7 @@ static const TRexChar *trex_matchnode(TRex* exp,TRexNode *node,const TRexChar *s
 				exp->_matches[capture].begin = cur;
 				exp->_currsubexp++;
 			}
-			
+
 			do {
 				TRexNode *subnext = NULL;
 				if(n->next != -1) {
@@ -484,10 +484,10 @@ static const TRexChar *trex_matchnode(TRex* exp,TRexNode *node,const TRexChar *s
 				}
 			} while((n->next != -1) && (n = &exp->_nodes[n->next]));
 
-			if(capture != -1) 
+			if(capture != -1)
 				exp->_matches[capture].len = cur - exp->_matches[capture].begin;
 			return cur;
-	}				 
+	}
 	case OP_WB:
 		if(str == exp->_bol && !isspace(*str)
 		 || (str == exp->_eol && !isspace(*(str-1)))

--- a/trex.c
+++ b/trex.c
@@ -590,8 +590,17 @@ TRexBool trex_match(TRex* exp,const TRexChar* text)
 	exp->_eol = text + scstrlen(text);
 	exp->_currsubexp = 0;
 	res = trex_matchnode(exp,exp->_nodes,text,NULL);
-	if(res == NULL || res != exp->_eol)
+
+	#ifdef _DEBUG
+		scprintf("DEBUG trex_match: res = '%s'\n", res);
+		scprintf("DEBUG trex_match: exp->_eol = '%s'\n", exp->_eol);
+	#endif
+
+	// Fail match if trex_matchnode returns nothing
+	if (!res) {
 		return TRex_False;
+	}
+
 	return TRex_True;
 }
 


### PR DESCRIPTION
Fixes #1 so that trex_match will return `TRex_True` when there's a match. Some simple tests are included in `test.c` now to test `trex_match`. Also had some white space cleanup came along for the ride.
